### PR TITLE
Fix circular dependency caused by ament_cmake_ros dependency

### DIFF
--- a/rosidlcpp_generator_c/CMakeLists.txt
+++ b/rosidlcpp_generator_c/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 set(CMAKE_CXX_STANDARD 23)
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 
 find_package(fmt REQUIRED)
 find_package(nlohmann_json REQUIRED)

--- a/rosidlcpp_generator_c/package.xml
+++ b/rosidlcpp_generator_c/package.xml
@@ -9,6 +9,8 @@
 
   <license>Apache License 2.0</license>
 
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
 
   <depend>nlohmann-json-dev</depend>

--- a/rosidlcpp_generator_cpp/package.xml
+++ b/rosidlcpp_generator_cpp/package.xml
@@ -9,6 +9,8 @@
 
   <license>Apache License 2.0</license>
 
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
 
   <depend>nlohmann-json-dev</depend>

--- a/rosidlcpp_generator_type_description/CMakeLists.txt
+++ b/rosidlcpp_generator_type_description/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(rosidlcpp_generator_type_description)
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 
 find_package(nlohmann_json REQUIRED)
 find_package(fmt REQUIRED)

--- a/rosidlcpp_generator_type_description/cmake/rosidlcpp_generator_type_description_generate_interfaces.cmake
+++ b/rosidlcpp_generator_type_description/cmake/rosidlcpp_generator_type_description_generate_interfaces.cmake
@@ -12,23 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# By default, without the settings below, find_package(Python3) will attempt
-# to find the newest python version it can, and additionally will find the
-# most specific version.  For instance, on a system that has
-# /usr/bin/python3.10, /usr/bin/python3.11, and /usr/bin/python3, it will find
-# /usr/bin/python3.11, even if /usr/bin/python3 points to /usr/bin/python3.10.
-# The behavior we want is to prefer the "system" installed version unless the
-# user specifically tells us othewise through the Python3_EXECUTABLE hint.
-# Setting CMP0094 to NEW means that the search will stop after the first
-# python version is found.  Setting Python3_FIND_UNVERSIONED_NAMES means that
-# the search will prefer /usr/bin/python3 over /usr/bin/python3.11.  And that
-# latter functionality is only available in CMake 3.20 or later, so we need
-# at least that version.
 cmake_minimum_required(VERSION 3.20)
-cmake_policy(SET CMP0094 NEW)
-set(Python3_FIND_UNVERSIONED_NAMES FIRST)
-
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 set(_output_path "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_type_description/${PROJECT_NAME}")
 set(_generated_files "")

--- a/rosidlcpp_generator_type_description/package.xml
+++ b/rosidlcpp_generator_type_description/package.xml
@@ -9,7 +9,8 @@
 
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <!-- Used in the CMakeLists.txt of this package and only needed by CMake-->
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
 

--- a/rosidlcpp_typesupport_c/CMakeLists.txt
+++ b/rosidlcpp_typesupport_c/CMakeLists.txt
@@ -11,7 +11,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rosidl_runtime_c REQUIRED)

--- a/rosidlcpp_typesupport_c/package.xml
+++ b/rosidlcpp_typesupport_c/package.xml
@@ -9,7 +9,7 @@
 
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <depend>rcpputils</depend>
   <depend>rcutils</depend>

--- a/rosidlcpp_typesupport_cpp/CMakeLists.txt
+++ b/rosidlcpp_typesupport_cpp/CMakeLists.txt
@@ -12,7 +12,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
+
 find_package(rcutils REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rosidl_runtime_c REQUIRED)

--- a/rosidlcpp_typesupport_cpp/package.xml
+++ b/rosidlcpp_typesupport_cpp/package.xml
@@ -9,7 +9,7 @@
 
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <depend>rcutils</depend>
   <depend>rcpputils</depend>

--- a/rosidlcpp_typesupport_fastrtps_c/CMakeLists.txt
+++ b/rosidlcpp_typesupport_fastrtps_c/CMakeLists.txt
@@ -25,7 +25,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 
 if(FASTRTPS_STATIC_DISABLE)
   ament_package()

--- a/rosidlcpp_typesupport_fastrtps_c/package.xml
+++ b/rosidlcpp_typesupport_fastrtps_c/package.xml
@@ -10,8 +10,7 @@
   <license>Apache License 2.0</license>
 
   <!-- Used in the CMakeLists.txt of this package and only needed by CMake-->
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
-  <buildtool_depend>ament_cmake_python</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <!-- Used in the projectConfig.cmake or generator extension and only needed by CMake -->
   <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>

--- a/rosidlcpp_typesupport_fastrtps_cpp/CMakeLists.txt
+++ b/rosidlcpp_typesupport_fastrtps_cpp/CMakeLists.txt
@@ -20,7 +20,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 
 find_package(fastcdr 2 REQUIRED CONFIG)
 

--- a/rosidlcpp_typesupport_fastrtps_cpp/package.xml
+++ b/rosidlcpp_typesupport_fastrtps_cpp/package.xml
@@ -10,8 +10,7 @@
   <license>Apache License 2.0</license>
 
   <!-- Used in the CMakeLists.txt of this package and only needed by CMake-->
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
-  <buildtool_depend>ament_cmake_python</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <!-- Used in the projectConfig.cmake or generator extension and only needed by CMake -->
   <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>

--- a/rosidlcpp_typesupport_introspection_c/CMakeLists.txt
+++ b/rosidlcpp_typesupport_introspection_c/CMakeLists.txt
@@ -12,8 +12,7 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake_python REQUIRED)
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 
 ament_export_dependencies(rosidl_runtime_c)
 ament_export_dependencies(rosidl_typesupport_interface)

--- a/rosidlcpp_typesupport_introspection_c/package.xml
+++ b/rosidlcpp_typesupport_introspection_c/package.xml
@@ -11,7 +11,7 @@
 
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>nlohmann-json-dev</depend>
   <depend>fmt</depend>

--- a/rosidlcpp_typesupport_introspection_cpp/CMakeLists.txt
+++ b/rosidlcpp_typesupport_introspection_cpp/CMakeLists.txt
@@ -12,8 +12,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake_python REQUIRED)
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(rosidl_runtime_cpp REQUIRED)
 find_package(rosidl_typesupport_introspection_c REQUIRED)
 

--- a/rosidlcpp_typesupport_introspection_cpp/package.xml
+++ b/rosidlcpp_typesupport_introspection_cpp/package.xml
@@ -11,7 +11,7 @@
 
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>nlohmann-json-dev</depend>
   <depend>fmt</depend>


### PR DESCRIPTION
Packages with ament_cmake_ros as a buildtool_depend would cause a circular dependency on the buildfarm.

Fixes #3

Tested by running the part of the buildfarm locally