### PR TITLE
Fix missing fmt dependency in rosidlcpp_generator_core

### DIFF
--- a/rosidlcpp_generator_core/package.xml
+++ b/rosidlcpp_generator_core/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>nlohmann-json-dev</build_depend>
+  <depend>fmt</depend>
   <depend>rosidlcpp_parser</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/rosidlcpp_generator_type_description/package.xml
+++ b/rosidlcpp_generator_type_description/package.xml
@@ -14,8 +14,12 @@
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
 
-  <exec_depend>rosidlcpp_parser</exec_depend>
-  <exec_depend>rosidlcpp_generator_core</exec_depend>
+  <depend>nlohmann-json-dev</depend>
+  <depend>fmt</depend>
+  <depend>rosidlcpp_parser</depend>
+  <depend>rosidlcpp_generator_core</depend>
+  <depend>rcutils</depend>
+  <depend>rosidl_runtime_c</depend>
 
   <member_of_group>rosidl_generator_packages</member_of_group>
 

--- a/rosidlcpp_typesupport_fastrtps_c/package.xml
+++ b/rosidlcpp_typesupport_fastrtps_c/package.xml
@@ -11,6 +11,7 @@
 
   <!-- Used in the CMakeLists.txt of this package and only needed by CMake-->
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <!-- Used in the projectConfig.cmake or generator extension and only needed by CMake -->
   <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>

--- a/rosidlcpp_typesupport_fastrtps_cpp/package.xml
+++ b/rosidlcpp_typesupport_fastrtps_cpp/package.xml
@@ -11,6 +11,7 @@
 
   <!-- Used in the CMakeLists.txt of this package and only needed by CMake-->
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <!-- Used in the projectConfig.cmake or generator extension and only needed by CMake -->
   <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>


### PR DESCRIPTION
+ other update to rosidlcpp_generator_type_description and rosidlcpp_typesupport_fastrtps_*