### PR TITLE
Fix rosidlcpp_parser build failures for Lyrical

### DIFF
--- a/rosidlcpp_parser/package.xml
+++ b/rosidlcpp_parser/package.xml
@@ -12,6 +12,8 @@
   <build_depend>nlohmann-json-dev</build_depend>
   <build_depend>fmt</build_depend>
 
+  <exec_depend>rosidl_pycommon</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/rosidlcpp_parser/src/rosidlcpp_parser/rosidlcpp_parser.cpp
+++ b/rosidlcpp_parser/src/rosidlcpp_parser/rosidlcpp_parser.cpp
@@ -907,7 +907,7 @@ std::optional<json> get_constants(const json& current_node, const std::string& m
     for (const auto& module : current_node["modules"]) {
       if (module.contains("name") && module["name"] == message_name + "_Constants") {
         if (module.contains("constants")) {
-          return module["constants"];
+          return module["constants"].get<json>();
         }
       }
     }


### PR DESCRIPTION
This PR fixes two issues blocking the build of rosidlcpp_parser in the Lyrical distribution (Ubuntu Resolute):

1. **Missing Dependency**: Added `rosidl_pycommon` to `package.xml`. This resolves an `ImportError` because the `rosidl` CLI tools used by this package require `rosidl_pycommon`.
2. **Ambiguous Conversion**: Fixed a compiler error in `rosidlcpp_parser.cpp` where `nlohmann::json` was being returned as a `std::optional<json>`. Newer compilers (GCC 15) flag this as ambiguous; replaced with an explicit `.get<json>()` call.

Verified on Ubuntu Resolute (26.04) with GCC 15.

Assisted-by: Gemini CLI:2.0-Flash